### PR TITLE
Автозагрузка параметров клиента.

### DIFF
--- a/src/components/Checkout/Checkout.vue
+++ b/src/components/Checkout/Checkout.vue
@@ -2,15 +2,12 @@
     <div>
         <Hero :title="`Оформить заказ`"/>
         <Cart/>
-        <ClientAutofill>
-            <StoreSelector/>
-            <CheckoutForm/>
-        </ClientAutofill>
+        <StoreSelector/>
+        <CheckoutForm/>
     </div>
 </template>
 
 <script>
-    import ClientAutofill from "@/components/Client/ClientAutofill";
     import StoreSelector from "@/components/Store/StoreSelector";
     import CheckoutForm from "@/components/Checkout/CheckoutForm";
     import Hero from "@/components/Hero";
@@ -18,7 +15,7 @@
 
     export default {
         name: "Checkout",
-        components: {Hero, ClientAutofill, StoreSelector, CheckoutForm, Cart},
+        components: {Hero, StoreSelector, CheckoutForm, Cart},
         created() {
             this.returnIfEmptyCart();
         },

--- a/src/components/Client/ClientAutofill.vue
+++ b/src/components/Client/ClientAutofill.vue
@@ -51,6 +51,7 @@
             formApiResponse(clientInfo, response) {
                 clientInfo.name = clientInfo.name ? clientInfo.name : response.name;
                 clientInfo.address = response.address;
+                clientInfo.phone = response.phone;
                 clientInfo.lastStore = JSON.parse(response.lastStore);
             }
         }

--- a/src/components/Client/ClientAutofill.vue
+++ b/src/components/Client/ClientAutofill.vue
@@ -1,12 +1,9 @@
-<template>
-    <div>
-        <slot/>
-    </div>
-</template>
-
 <script>
     export default {
         name: "ClientAutofill",
+        render() {
+            return null
+        },
         created() {
             const queryString = window.location.search;
             const urlParams = new URLSearchParams(queryString);

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,5 +1,6 @@
 <template>
     <div>
+        <ClientAutofill/>
         <Hero title="Заказ Доставки"/>
         <Categories :category-names="categoryNames" @select="selectCategory">
             <MenuCard
@@ -39,10 +40,12 @@
     import Collapsable from "@/components/Visual/Collapsable";
     import MenuDetails from "@/components/Menu/MenuDetails";
     import MenuQtyInCart from "@/components/Menu/MenuQtyInCart";
+    import ClientAutofill from "@/components/Client/ClientAutofill";
 
     export default {
         name: 'Menu',
         components: {
+            ClientAutofill,
             MenuQtyInCart,
             MenuDetails,
             Collapsable,


### PR DESCRIPTION
Поскольку параметры клиента передаются в параметрах url, автозагрузка параметров клиента перенесена в меню. При смене роута параметры пропадают и в Checkout.vue загрузка через api никогда не сработает, потому, что она срабатывает только при переданном номере карты в параметрах.